### PR TITLE
docs(all): view source link is broken

### DIFF
--- a/website/docs/calendar/example.md
+++ b/website/docs/calendar/example.md
@@ -3,7 +3,7 @@ sidebar_position: 2
 title: Example
 ---
 
-[View Source on GitHub](https://github.com/h6s-dev/h6s/tree/main/examples/calendar)
+[View Source on GitHub](https://github.com/h6s-dev/h6s/blob/main/examples/react/src/pages/calendar/index.tsx)
 
 ```tsx
 import { useCalendar } from '@h6s/calendar'

--- a/website/docs/table/example.md
+++ b/website/docs/table/example.md
@@ -3,7 +3,7 @@ sidebar_position: 2
 title: Example
 ---
 
-[View Source on GitHub](https://github.com/h6s-dev/h6s/tree/main/examples/calendar)
+[View Source on GitHub](https://github.com/h6s-dev/h6s/blob/main/examples/react/src/pages/table/index.tsx)
 
 ```tsx
 import { useCalendar } from '@h6s/calendar'


### PR DESCRIPTION
<img width="1053" alt="image" src="https://user-images.githubusercontent.com/18658235/180949866-6c907725-1820-4617-bb3e-78781b85eb16.png">

https://h6s.dev/docs/table/example , https://h6s.dev/docs/calendar/example `View Source on GitHub` link is broken :) 