### PR TITLE
docs(examples): add an index to the argument of register function in table fields

### DIFF
--- a/examples/react/src/pages/table/index.tsx
+++ b/examples/react/src/pages/table/index.tsx
@@ -150,10 +150,10 @@ export default function TableExample() {
               })}>
               <DrawerBody>
                 <Stack spacing={4}>
-                  {Object.entries(instance.headMeta).map(([id, { label, show, countOfChild, countOfParent }]) => {
+                  {Object.entries(instance.headMeta).map(([id, { label, show, countOfChild, countOfParent }], index) => {
                     return (
                       <Checkbox
-                        {...register('headIds')}
+                        {...register(`headIds.${index}`)}
                         key={id}
                         size="lg"
                         value={id}


### PR DESCRIPTION
Fix an argument of the register function. react-hook-form requires a dot and number to produce an array of fields. ([useform/register#rules](https://react-hook-form.com/api/useform/register#rules))

it closes https://github.com/h6s-dev/h6s/issues/198