### PR TITLE
fix(package.json): remove unnecessary files in published package

### DIFF
--- a/packages/calendar/package.json
+++ b/packages/calendar/package.json
@@ -4,6 +4,10 @@
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "module": "esm/index.mjs",
+  "files": [
+    "dist",
+    "esm"
+  ],
   "sideEffects": false,
   "publishConfig": {
     "access": "public"

--- a/packages/table/package.json
+++ b/packages/table/package.json
@@ -4,6 +4,10 @@
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "module": "esm/index.mjs",
+  "files": [
+    "dist",
+    "esm"
+  ],
   "sideEffects": false,
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
# There is unnecessary files in user of this packages(@h6s/table, @h6s/calendar)
You can see unnecessary files(**tsconfig.json, playwright.config.ts, src, .e2e**) if install this packages.
<img width="442" alt="image" src="https://user-images.githubusercontent.com/61593290/206916694-012d847f-8c2c-42ef-b960-73aace5bf559.png">

## Solution: How about using [files field of package.json](https://docs.npmjs.com/cli/v9/configuring-npm/package-json#files).
I used files filed as ["dist", "esm"], but we don't have to worry about ignoring necessary files like package.json, README, LICENSE that almost be used as filename in @h6s/table, @h6s/calendar. because below filename will be contained in package defaultly.

Certain files are always included, regardless of settings:

- package.json
- README
- LICENSE / LICENCE
- The file in the "main" field
- README & LICENSE can have any case and extension.

package.json have to narrow files to publish package contain only necessary. by using files field, we can narrow package's files. so I added files field

```json
{
  "files": [
    "dist",
    "esm"
  ],
}
```