### PR TITLE
fix(package.json): edit main, exports and publishConfig to improve DX

### DIFF
--- a/packages/calendar/package.json
+++ b/packages/calendar/package.json
@@ -1,16 +1,33 @@
 {
   "name": "@h6s/calendar",
   "version": "1.0.7",
-  "main": "dist/index.js",
-  "types": "dist/index.d.ts",
-  "module": "esm/index.mjs",
+  "sideEffects": false,
+  "main": "./src/index.ts",
   "files": [
     "dist",
     "esm"
   ],
-  "sideEffects": false,
+  "exports": {
+    ".": {
+      "require": "./src/index.ts",
+      "import": "./src/index.ts"
+    },
+    "./package.json": "./package.json"
+  },
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "require": "./dist/index.js",
+        "import": "./esm/index.mjs"
+      },
+      "./package.json": "./package.json"
+    },
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts",
+    "import": "./esm/index.mjs",
+    "module": "./esm/index.mjs"
   },
   "scripts": {
     "prepack": "yarn build",

--- a/packages/calendar/package.json
+++ b/packages/calendar/package.json
@@ -2,7 +2,7 @@
   "name": "@h6s/calendar",
   "version": "1.0.7",
   "sideEffects": false,
-  "main": "./src/index.ts",
+  "main": "src/index.ts",
   "files": [
     "dist",
     "esm"
@@ -24,10 +24,10 @@
       },
       "./package.json": "./package.json"
     },
-    "main": "./dist/index.js",
-    "types": "./dist/index.d.ts",
-    "import": "./esm/index.mjs",
-    "module": "./esm/index.mjs"
+    "main": "dist/index.js",
+    "types": "dist/index.d.ts",
+    "import": "esm/index.mjs",
+    "module": "esm/index.mjs"
   },
   "scripts": {
     "prepack": "yarn build",

--- a/packages/table/package.json
+++ b/packages/table/package.json
@@ -2,7 +2,7 @@
   "name": "@h6s/table",
   "version": "1.0.4",
   "sideEffects": false,
-  "main": "./src/index.ts",
+  "main": "src/index.ts",
   "files": [
     "dist",
     "esm"
@@ -24,10 +24,10 @@
       },
       "./package.json": "./package.json"
     },
-    "main": "./dist/index.js",
-    "types": "./dist/index.d.ts",
-    "import": "./esm/index.mjs",
-    "module": "./esm/index.mjs"
+    "main": "dist/index.js",
+    "types": "dist/index.d.ts",
+    "import": "esm/index.mjs",
+    "module": "esm/index.mjs"
   },
   "scripts": {
     "prepack": "yarn build",

--- a/packages/table/package.json
+++ b/packages/table/package.json
@@ -1,16 +1,33 @@
 {
   "name": "@h6s/table",
   "version": "1.0.4",
-  "main": "dist/index.js",
-  "types": "dist/index.d.ts",
-  "module": "esm/index.mjs",
+  "sideEffects": false,
+  "main": "./src/index.ts",
   "files": [
     "dist",
     "esm"
   ],
-  "sideEffects": false,
+  "exports": {
+    ".": {
+      "require": "./src/index.ts",
+      "import": "./src/index.ts"
+    },
+    "./package.json": "./package.json"
+  },
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "require": "./dist/index.js",
+        "import": "./esm/index.mjs"
+      },
+      "./package.json": "./package.json"
+    },
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts",
+    "import": "./esm/index.mjs",
+    "module": "./esm/index.mjs"
   },
   "scripts": {
     "prepack": "yarn build",


### PR DESCRIPTION
# Edit main, exports and publishConfig to improve DX

## Cannot find module directly, if contributors didn't build packages.
<img width="775" alt="image" src="https://user-images.githubusercontent.com/61593290/206915965-81eb91af-cc09-43d9-9c61-402be22f8141.png">
Though there is built packages, Contributor want to access source itself, not built package.

## Solution I thought
How about making vscode access to workspaces source code directly, not built package. if package.json using publishConfig, making built package and developing package in workspaces for DX separately is available.
```json
{
  "main": "src/index.ts",
  "exports": {
    ".": {
      "require": "./src/index.ts",
      "import": "./src/index.ts"
    },
    "./package.json": "./package.json"
  },
  "publishConfig": {
    "access": "public",
    "exports": {
      ".": {
        "require": "./dist/index.js",
        "import": "./esm/index.mjs",
        "types": "./dist/index.d.ts"
      },
      "./package.json": "./package.json"
    },
    "import": "./esm/index.mjs",
    "main": "./dist/index.js",
    "types": "dist/index.d.ts",
    "module": "esm/index.mjs"
  },
}
```
