### PR TITLE
chore: change 'weekends' and 'weekDays' to 'weekdays'

### DIFF
--- a/examples/react/src/pages/calendar/index.tsx
+++ b/examples/react/src/pages/calendar/index.tsx
@@ -105,9 +105,9 @@ export default function CalendarExample() {
           </TableCaption>
           <Thead>
             <Tr>
-              {headers.weekDays.map(({ key, value }) => {
+              {headers.weekdays.map(({ key, value }) => {
                 return (
-                  <Th key={key} data-testid="calendar-weekends">
+                  <Th key={key} data-testid="calendar-weekdays">
                     {format(value, "E", { locale })}
                   </Th>
                 );

--- a/examples/react/src/pages/index.tsx
+++ b/examples/react/src/pages/index.tsx
@@ -103,9 +103,9 @@ export default function BasicExample() {
         </TableCaption>
         <Thead>
           <Tr>
-            {headers.weekDays.map(({ key, value }) => {
+            {headers.weekdays.map(({ key, value }) => {
               return (
-                <Th key={key} data-testid="calendar-weekends">
+                <Th key={key} data-testid="calendar-weekdays">
                   {format(value, "E", { locale })}
                 </Th>
               );

--- a/packages/calendar/.e2e/basic.e2e.ts
+++ b/packages/calendar/.e2e/basic.e2e.ts
@@ -12,6 +12,7 @@ const BASIC_EXAMPLES_URL =
 
 const SELECTOR = {
   CURSOR_DATE: 'data-testid=cursor-date',
+  WEEKDAYS: 'data-testid=calendar-weekdays',
   WEEKS: 'data-testid=calendar-weeks',
   CELL_TODAY: 'data-testid=calendar-cell--today',
 }
@@ -35,9 +36,9 @@ test('render calendar successfully', async ({ page }) => {
   const pageTitle = page.locator(SELECTOR.CURSOR_DATE)
   await expect(pageTitle).toHaveText(dateFormat(baseDate))
 
-  // render weekends in calendar
-  const weekendsCount = await page.locator('data-testid=calendar-weekends').count()
-  expect(weekendsCount).toBe(7)
+  // render weekdays in calendar
+  const weekdaysCount = await page.locator(SELECTOR.WEEKDAYS).count()
+  expect(weekdaysCount).toBe(7)
 
   // render calendar cells
   const weeksCount = await page.locator(SELECTOR.WEEKS).count()

--- a/packages/calendar/src/core/createCalendarInfo.ts
+++ b/packages/calendar/src/core/createCalendarInfo.ts
@@ -7,7 +7,7 @@ export default function createCalendarInfo(cursorDate: Date, { weekStartsOn }: {
   const { year, month, day } = parseDate(cursorDate);
   const startWeekdayInMonth = getStartWeekdayInMonth(cursorDate, weekStartsOn);
   const weeksInMonth = getWeeksInMonth(cursorDate, startWeekdayInMonth);
-  const weekDays = arrayOf(7).map((index) => ({
+  const weekdays = arrayOf(7).map((index) => ({
     value: setDay(cursorDate, index + weekStartsOn),
   }));
 
@@ -25,7 +25,7 @@ export default function createCalendarInfo(cursorDate: Date, { weekStartsOn }: {
     weekStartsOn,
     startWeekdayInMonth,
     weeksInMonth,
-    weekDays,
+    weekdays,
     today: {
       weekIndex: getCurrentWeekIndex(day, startWeekdayInMonth),
       dateIndex: getDay(cursorDate),

--- a/packages/calendar/src/stories/Calendar.tsx
+++ b/packages/calendar/src/stories/Calendar.tsx
@@ -36,9 +36,9 @@ export function Calendar() {
       </caption>
       <thead>
         <tr>
-          {headers.weekDays.map(({ key, value }) => {
+          {headers.weekdays.map(({ key, value }) => {
             return (
-              <th key={key} data-testid="calendar-weekends">
+              <th key={key} data-testid="calendar-weekdays">
                 {format(value, "E")}
               </th>
             );

--- a/packages/calendar/src/useCalendar.test.ts
+++ b/packages/calendar/src/useCalendar.test.ts
@@ -22,11 +22,11 @@ describe("useCalendar hooks test", () => {
         }),
       );
       // Then
-      const onlyDates = result.current.headers.weekDays.map(({ value }) => ({
+      const onlyDates = result.current.headers.weekdays.map(({ value }) => ({
         value,
       }));
       expect(onlyDates).toEqual(DecemberFirstWeekData.value[0].value);
-      expect(result.current.headers.weekDays[0].key).toBeDefined();
+      expect(result.current.headers.weekdays[0].key).toBeDefined();
     });
 
     it("return weekdays array when month viewType", () => {
@@ -43,13 +43,13 @@ describe("useCalendar hooks test", () => {
         }),
       );
       // Then
-      const onlyDates = result.current.headers.weekDays.map(({ value }) => ({
+      const onlyDates = result.current.headers.weekdays.map(({ value }) => ({
         value,
       }));
       expect(onlyDates).toEqual([{ value: defaultDate }]);
     });
 
-    it("return weekDays when set WeekDayType: 0", () => {
+    it("return weekdays when set WeekDayType: 0", () => {
       // Given
       const defaultDate = new Date(2021, 8, 30);
       const defaultWeekStart = 0;
@@ -61,7 +61,7 @@ describe("useCalendar hooks test", () => {
         }),
       );
       // Then
-      const onlyDates = result.current.headers.weekDays.map(({ value }) => ({
+      const onlyDates = result.current.headers.weekdays.map(({ value }) => ({
         value,
       }));
       expect(onlyDates).toEqual([
@@ -74,7 +74,7 @@ describe("useCalendar hooks test", () => {
         { value: new Date(2021, 9, 2) },
       ]);
     });
-    it("return weekDays when set WeekDayType: 1", () => {
+    it("return weekdays when set WeekDayType: 1", () => {
       // Given
       const defaultDate = new Date(2021, 8, 30);
       const defaultWeekStart = 1;
@@ -86,7 +86,7 @@ describe("useCalendar hooks test", () => {
         }),
       );
       // Then
-      const onlyDates = result.current.headers.weekDays.map(({ value }) => ({
+      const onlyDates = result.current.headers.weekdays.map(({ value }) => ({
         value,
       }));
       expect(onlyDates).toEqual([

--- a/packages/calendar/src/useCalendar.ts
+++ b/packages/calendar/src/useCalendar.ts
@@ -30,7 +30,7 @@ export function useCalendar({
   const [viewType, setViewType] = useState(defaultViewType);
 
   const calendar = createCalendarInfo(cursorDate, { weekStartsOn });
-  const { weekDays, weeksInMonth, today, getDateCellByIndex } = calendar;
+  const { weekdays, weeksInMonth, today, getDateCellByIndex } = calendar;
 
   const getHeaders = useCallback(
     (viewType: CalendarViewType) => {
@@ -38,15 +38,15 @@ export function useCalendar({
         case CalendarViewType.Month:
         case CalendarViewType.Week:
           return {
-            weekDays: withKey(weekDays, "weekdays"),
+            weekdays: withKey(weekdays, "weekdays"),
           };
         default:
           return {
-            weekDays: withKey([{ value: cursorDate }], "weekdays"),
+            weekdays: withKey([{ value: cursorDate }], "weekdays"),
           };
       }
     },
-    [cursorDate, weekDays],
+    [cursorDate, weekdays],
   );
 
   const createMatrix = useCallback(

--- a/website/docs/calendar/example.md
+++ b/website/docs/calendar/example.md
@@ -15,7 +15,7 @@ export default function Calendar() {
     <Table>
       <Thead>
         <Tr>
-          {headers.weekDays.map(({ key, value }) => {
+          {headers.weekdays.map(({ key, value }) => {
             return <Th key={key}>{format(value, 'E', { locale })}</Th>
           })}
         </Tr>

--- a/website/docs/calendar/get-started.md
+++ b/website/docs/calendar/get-started.md
@@ -45,7 +45,7 @@ export default function Calendar() {
     <Table>
       <Thead>
         <Tr>
-          {headers.weekDays.map(({ key, value }) => {
+          {headers.weekdays.map(({ key, value }) => {
             return <Th key={key}>{format(value, 'E', { locale })}</Th>
           })}
         </Tr>


### PR DESCRIPTION
It is an extension of work [PR](https://github.com/h6s-dev/h6s/pull/313)

Since weekday is a noun(명사) in itself.
I turned off the camel case. (weekDays -> weekdays)