### PR TITLE
docs(table): fix table example code

### DIFF
--- a/website/docs/table/example.md
+++ b/website/docs/table/example.md
@@ -39,7 +39,7 @@ export default function Table() {
                 cell.colSpan !== 0
                   ? <td key={cell.id}>{cell.render({ cellProps: cell })}</td>
                   : null
-              )}
+              ))}
             </tr>
           )
         })}

--- a/website/docs/table/get-started.md
+++ b/website/docs/table/get-started.md
@@ -137,7 +137,7 @@ export default function Table() {
                 cell.colSpan !== 0
                   ? <td key={cell.id}>{cell.render({ cellProps: cell })}</td>
                   : null
-              )}
+              ))}
             </tr>
           )
         })}


### PR DESCRIPTION
In Table Example Docs (https://h6s.dev/docs/table/get-started)

The brackets are set incorrectly, I can fixed it.

thank you. :) 